### PR TITLE
fixes linux build dependencies

### DIFF
--- a/src/vtray.c.v
+++ b/src/vtray.c.v
@@ -6,10 +6,12 @@ $if windows {
 
 $if linux {
 	#define TRAY_APPINDICATOR 1
-	#pkgconfig --cflags gtk+-2.0
-	#pkgconfig --cflags appindicator3-0.1
-	#pkgconfig --cflags gdk-pixbuf-2.0
-	#flag linux -lappindicator3
+        #pkgconfig --cflags gtk+-3.0
+        #pkgconfig --cflags appindicator-0.1
+        #pkgconfig --cflags gdk-pixbuf-2.0
+        #flag linux -lgtk-3        
+        #flag linux -lgobject-2.0
+        #flag linux -lappindicator3
 }
 
 $if macos {


### PR DESCRIPTION
I had the issue that the current implementation causes several issues when creating a production build on Ubuntu 22.04.3 via `v -prod .`.

The first issue i experienced was the package appindicator3 didn't exist - it is called appindicator-0.1 on my distribution.
As i am not experienced very much with dependency hells in C programming language, i gave a check using
```
$ pkg-config --list-all | grep appindi
appindicator-0.1                    appindicator-0.1 - Application indicators
ayatana-appindicator3-0.1           ayatana-appindicator3-0.1 - Ayatana Application Indicators (for GTK-3+)
```
Switching to appindicator-0.1 caused
```
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/libappindicator3.so: undefined reference to symbol 'gtk_menu_get_type'
/usr/bin/ld: /lib/x86_64-linux-gnu/libgtk-3.so.0: DSO missing from command line
collect2: error: ld returned 1 exit status
builder error: 
==================
C error. This should never happen.
```

I solved this by applying the flag `-lgtk-3`, which afterwards caused 

```
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/libappindicator3.so: undefined reference to symbol 'g_type_check_instance_cast'
/usr/bin/ld: /lib/x86_64-linux-gnu/libgobject-2.0.so.0: DSO missing from command line
collect2: error: ld returned 1 exit status
builder error: 
==================
C error. This should never happen.
```

Applying the flag `-lgobject-2.0` finally solved the dependency hell.

If you see better approaches to create a stable production build, please feel free to optimize my proposal.

Thank you very much for this wrapper, having tray support is very helpful for tool creation.
