### PR TITLE
fix compatibility wih v 0.4.6

### DIFF
--- a/src/vtray.c.v
+++ b/src/vtray.c.v
@@ -66,7 +66,6 @@ pub fn new() &Tray {
 
 type FnTrayMenuCb = fn (mut mi MenuItem)
 
-[params]
 pub struct MenuItem {
 pub mut:
 	text     string


### PR DESCRIPTION
Reason is `[param]` is not allowed anymore for structs used as parameter since v 0.4.6 regarding changelog.
Switching to `@[param]` raises way more issues.
After change it compiles without warnings on Ubuntu 22.04.
See https://github.com/vlang/v/pull/21206 for details.